### PR TITLE
Set NHRF related configuration

### DIFF
--- a/bin.sh
+++ b/bin.sh
@@ -39,15 +39,16 @@ done
 
 
 # Default parameters
-ALLOW_SELF_REGISTER="true"
+ALLOW_SELF_REGISTER="false"
 ENABLE_LAMBDA_SNAPSTART="false"
+#IPV4_RANGES="185.229.26.21/32"
 IPV4_RANGES=""
 IPV6_RANGES=""
 DISABLE_IPV6="false"
 ALLOWED_SIGN_UP_EMAIL_DOMAINS=""
-BEDROCK_REGION="us-east-1"
+BEDROCK_REGION="eu-central-1"
 CDK_JSON_OVERRIDE="{}"
-REPO_URL="https://github.com/aws-samples/bedrock-chat.git"
+REPO_URL="https://github.com/PCG-International/nhrf-bedrock-chat.git"
 VERSION="v3"
 
 # Parse command-line arguments for customization

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -51,14 +51,19 @@
     "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
     "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
     "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true,
-    "bedrockRegion": "us-east-1",
+    "bedrockRegion": "eu-central-1",
     "allowedIpV4AddressRanges": ["0.0.0.0/1", "128.0.0.0/1"],
     "allowedIpV6AddressRanges": [
       "0000:0000:0000:0000:0000:0000:0000:0000/1",
       "8000:0000:0000:0000:0000:0000:0000:0000/1"
     ],
-    "identityProviders": [],
-    "userPoolDomainPrefix": "",
+    "identityProviders": [
+       {
+        "service": "google",
+        "secretName": "googleOAuthCredentials"
+      }
+    ],
+    "userPoolDomainPrefix": "nhrf",
     "allowedSignUpEmailDomains": [],
     "autoJoinUserGroups": ["CreatingBotAllowed"],
     "selfSignUpEnabled": true,

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -1,7 +1,10 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/bedrock-chat.ts",
   "watch": {
-    "include": ["**", "../backend"],
+    "include": [
+      "**",
+      "../backend"
+    ],
     "exclude": [
       "README.md",
       "../backend/**/__pycache__",
@@ -20,7 +23,10 @@
   "context": {
     "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
     "@aws-cdk/core:checkSecretUsage": true,
-    "@aws-cdk/core:target-partitions": ["aws", "aws-cn"],
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
     "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
     "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
     "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
@@ -52,22 +58,30 @@
     "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
     "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true,
     "bedrockRegion": "eu-central-1",
-    "allowedIpV4AddressRanges": ["0.0.0.0/1", "128.0.0.0/1"],
+    "allowedIpV4AddressRanges": [
+      "0.0.0.0/1",
+      "128.0.0.0/1"
+    ],
     "allowedIpV6AddressRanges": [
       "0000:0000:0000:0000:0000:0000:0000:0000/1",
       "8000:0000:0000:0000:0000:0000:0000:0000/1"
     ],
     "identityProviders": [
-       {
+      {
         "service": "google",
         "secretName": "googleOAuthCredentials"
       }
     ],
     "userPoolDomainPrefix": "nhrf",
     "allowedSignUpEmailDomains": [],
-    "autoJoinUserGroups": ["CreatingBotAllowed"],
+    "autoJoinUserGroups": [
+      "CreatingBotAllowed"
+    ],
     "selfSignUpEnabled": true,
-    "publishedApiAllowedIpV4AddressRanges": ["0.0.0.0/1", "128.0.0.0/1"],
+    "publishedApiAllowedIpV4AddressRanges": [
+      "0.0.0.0/1",
+      "128.0.0.0/1"
+    ],
     "publishedApiAllowedIpV6AddressRanges": [
       "0000:0000:0000:0000:0000:0000:0000:0000/1",
       "8000:0000:0000:0000:0000:0000:0000:0000/1"
@@ -78,7 +92,7 @@
     "enableBotStore": true,
     "botStoreLanguage": "en",
     "tokenValidMinutes": 30,
-    "alternateDomainName": "",
+    "alternateDomainName": "ai-pilot.eie.gr/",
     "hostedZoneId": "",
     "devAccessIamRoleArn": ""
   }


### PR DESCRIPTION
This pull request introduces several configuration updates to improve deployment customization and align the project settings with new requirements. The key changes involve modifying default parameters, updating regional settings, enhancing identity provider support, and specifying domain configurations.

### Configuration Updates:

#### Default Parameters:
* Changed `ALLOW_SELF_REGISTER` from `"true"` to `"false"` in `bin.sh` to disable self-registration.
* Updated `BEDROCK_REGION` from `"us-east-1"` to `"eu-central-1"` in `bin.sh` to reflect the new deployment region.
* Replaced `REPO_URL` with `"https://github.com/PCG-International/nhrf-bedrock-chat.git"` to point to the updated repository.

#### Identity Provider Enhancements:
* Added Google OAuth credentials as an identity provider in `cdk.json` under `identityProviders`.
* Set `userPoolDomainPrefix` to `"nhrf"` to customize the user pool domain.

#### Regional and Domain Settings:
* Updated `bedrockRegion` in `cdk.json` from `"us-east-1"` to `"eu-central-1"` to align with the new region.
* Specified `alternateDomainName` as `"ai-pilot.eie.gr/"` in `cdk.json` for the deployment.