### PR TITLE
[Feature] Add EPUB file upload support for simple chat interface

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -17,17 +17,19 @@ poetry install
 
 - Configure environment variables
 
+Create a `.env` file in the backend directory with:
+
 ```sh
-export CONVERSATION_TABLE_NAME=BedrockChatStack-DatabaseConversationTablexxxx
-export BOT_TABLE_NAME=BedrockChatStack-DatabaseBotTablexxxx
-export ACCOUNT=yyyy
-export REGION=ap-northeast-1
-export BEDROCK_REGION=us-east-1
-export DOCUMENT_BUCKET=bedrockchatstack-documentbucketxxxxxxx
-export LARGE_MESSAGE_BUCKET=bedrockchatstack-largemessagebucketxxx
-export USER_POOL_ID=xxxxxxxxx
-export CLIENT_ID=xxxxxxxxx
-export OPENSEARCH_DOMAIN_ENDPOINT=https://abcdefghijklmnopqrst.aa-region-1.aoss.amazonaws.com
+REGION=eu-central-1
+AWS_REGION=eu-central-1
+BEDROCK_REGION=eu-central-1
+CONVERSATION_TABLE_NAME=BedrockChatStack-DatabaseConversationTablexxxx
+BOT_TABLE_NAME=BedrockChatStack-DatabaseBotTablexxxx
+DOCUMENT_BUCKET_NAME=bedrockchatstack-documentbucketxxxxxxx
+LARGE_MESSAGE_BUCKET_NAME=bedrockchatstack-largemessagebucketxxx
+USER_POOL_ID=xxxxxxxxx
+CLIENT_ID=xxxxxxxxx
+BOT_STORE_OPENSEARCH_ENDPOINT=https://abcdefghijklmnopqrst.aa-region-1.aoss.amazonaws.com
 ```
 
 - Configure CDK configration.
@@ -67,7 +69,7 @@ Local development requires OpenSearch data access permissions for the IAM role t
 ## Launch local server
 
 ```sh
-poetry run uvicorn app.main:app  --reload --host 0.0.0.0 --port 8000
+env $(cat .env | xargs) poetry run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
 - To refer the specification, access to [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs) for [Swagger](https://swagger.io/) and [http://127.0.0.1:8000/redoc](http://127.0.0.1:8000/redoc) for [Redoc](https://github.com/Redocly/redoc).

--- a/backend/app/repositories/models/conversation.py
+++ b/backend/app/repositories/models/conversation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import logging
 import re
@@ -163,6 +164,7 @@ def _is_converse_supported_document_format(ext: str) -> TypeGuard[DocumentFormat
         "html",
         "txt",
         "md",
+        "epub",
     }
     return ext in supported_formats
 
@@ -243,6 +245,7 @@ class AttachmentContentModel(BaseModel):
             ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             ".xls": "application/vnd.ms-excel",
             ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ".epub": "application/epub+zip",
         }
 
         media_type = mime_type_map.get(file_ext, "application/octet-stream")
@@ -291,6 +294,45 @@ class AttachmentContentModel(BaseModel):
                 )
                 # Continue with normal processing if validation fails
 
+        # Special handling for EPUB files - extract text and convert to HTML
+        if file_ext == ".epub":
+            try:
+                extracted_text = self._extract_epub_text(file_bytes)
+                if extracted_text:
+                    # Convert extracted text to HTML format for better processing
+                    html_content = f"<html><body><h1>{Path(self.file_name).stem}</h1><div>{extracted_text}</div></body></html>"
+                    html_data = base64.b64encode(html_content.encode("utf-8")).decode(
+                        "utf-8"
+                    )
+
+                    return [
+                        {
+                            "type": "document",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "text/html",
+                                "data": html_data,
+                            },
+                        }
+                    ]
+                else:
+                    return [
+                        {
+                            "type": "text",
+                            "text": f"[EPUB Document: {self.file_name}]\n\nNote: Could not extract text from this EPUB file. The file may be corrupted or protected.",
+                        }
+                    ]
+            except Exception as e:
+                logger.warning(
+                    f"Failed to extract text from EPUB {self.file_name}: {e}"
+                )
+                return [
+                    {
+                        "type": "text",
+                        "text": f"[EPUB Document: {self.file_name}]\n\nNote: Error processing EPUB file. Please try with a different file format.",
+                    }
+                ]
+
         return [
             {
                 "type": "document",
@@ -301,6 +343,58 @@ class AttachmentContentModel(BaseModel):
                 },
             }
         ]
+
+    def _extract_epub_text(self, file_bytes: bytes) -> str:
+        """Extract text content from EPUB file bytes"""
+        try:
+            import ebooklib
+            from ebooklib import epub
+            from bs4 import BeautifulSoup
+            import tempfile
+            import os
+
+            # Create temporary file since ebooklib.epub.read_epub needs a file path
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".epub") as temp_file:
+                temp_file.write(file_bytes)
+                temp_file_path = temp_file.name
+
+            try:
+                # Create EPUB book from temporary file
+                book = epub.read_epub(temp_file_path)
+
+                # Extract text from all document items
+                text_content = []
+
+                # Get all document items (HTML/XHTML content)
+                for item in book.get_items():
+                    if item.get_type() == ebooklib.ITEM_DOCUMENT:
+                        # Get the content and parse with BeautifulSoup
+                        content = item.get_content().decode("utf-8", errors="ignore")
+                        soup = BeautifulSoup(content, "html.parser")
+
+                        # Extract text from paragraphs, maintaining some structure
+                        for paragraph in soup.find_all(
+                            ["p", "div", "span", "h1", "h2", "h3", "h4", "h5", "h6"]
+                        ):
+                            text = paragraph.get_text(strip=True)
+                            if text:
+                                text_content.append(text)
+
+                # Join all text with double newlines for readability
+                return "\n\n".join(text_content)
+            finally:
+                # Clean up temporary file
+                if os.path.exists(temp_file_path):
+                    os.unlink(temp_file_path)
+
+        except ImportError:
+            logger.error(
+                "ebooklib or beautifulsoup4 not installed - cannot process EPUB files"
+            )
+            return ""
+        except Exception as e:
+            logger.error(f"Error extracting text from EPUB: {e}")
+            return ""
 
 
 class FeedbackModel(BaseModel):

--- a/backend/app/repositories/models/conversation.py
+++ b/backend/app/repositories/models/conversation.py
@@ -294,25 +294,17 @@ class AttachmentContentModel(BaseModel):
                 )
                 # Continue with normal processing if validation fails
 
-        # Special handling for EPUB files - extract text and convert to HTML
+        # Special handling for EPUB files - extract text and return as text for invoke API
+        # (Claude 4 invoke API only accepts application/pdf for documents)
         if file_ext == ".epub":
             try:
                 extracted_text = self._extract_epub_text(file_bytes)
                 if extracted_text:
-                    # Convert extracted text to HTML format for better processing
-                    html_content = f"<html><body><h1>{Path(self.file_name).stem}</h1><div>{extracted_text}</div></body></html>"
-                    html_data = base64.b64encode(html_content.encode("utf-8")).decode(
-                        "utf-8"
-                    )
-
+                    # Return as text format since invoke API doesn't support EPUB documents
                     return [
                         {
-                            "type": "document",
-                            "source": {
-                                "type": "base64",
-                                "media_type": "text/html",
-                                "data": html_data,
-                            },
+                            "type": "text",
+                            "text": f"[EPUB Document: {self.file_name}]\n\n{extracted_text}",
                         }
                     ]
                 else:

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -58,6 +58,29 @@ files = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.13.4"
+description = "Screen-scraping library"
+optional = false
+python-versions = ">=3.7.0"
+groups = ["main"]
+files = [
+    {file = "beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b"},
+    {file = "beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195"},
+]
+
+[package.dependencies]
+soupsieve = ">1.2"
+typing-extensions = ">=4.0.0"
+
+[package.extras]
+cchardet = ["cchardet"]
+chardet = ["chardet"]
+charset-normalizer = ["charset-normalizer"]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "black"
 version = "24.10.0"
 description = "The uncompromising code formatter."
@@ -751,6 +774,22 @@ primp = ">=0.14.0"
 
 [package.extras]
 dev = ["mypy (>=1.14.1)", "pytest (>=8.3.4)", "pytest-dependency (>=0.6.0)", "ruff (>=0.9.2)"]
+
+[[package]]
+name = "ebooklib"
+version = "0.19"
+description = "Ebook library which can handle EPUB2/EPUB3 and Kindle format"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "ebooklib-0.19-py3-none-any.whl", hash = "sha256:a790e280e1d5ef105e350e34cc88b83c9c987fa6bab8a63a7543410c313cfa31"},
+    {file = "ebooklib-0.19.tar.gz", hash = "sha256:07e9b4db0a30c73623b14e23b315634a450d2c13f23d1dba4b457a6ca16a58be"},
+]
+
+[package.dependencies]
+lxml = "*"
+six = "*"
 
 [[package]]
 name = "ecdsa"
@@ -1616,6 +1655,18 @@ files = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.7"
+description = "A modern CSS selector implementation for Beautiful Soup."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4"},
+    {file = "soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a"},
+]
+
+[[package]]
 name = "starlette"
 version = "0.46.1"
 description = "The little ASGI library that shines."
@@ -1659,6 +1710,33 @@ groups = ["main"]
 files = [
     {file = "types_awscrt-0.25.7-py3-none-any.whl", hash = "sha256:7bcd649aedca3c41007ca5757096d3b3bdb454b73ca66970ddae6c2c2f541c8c"},
     {file = "types_awscrt-0.25.7.tar.gz", hash = "sha256:e11298750c99647f7f3b98d6d6d648790096cd32d445fd0d49a6041a63336c9a"},
+]
+
+[[package]]
+name = "types-beautifulsoup4"
+version = "4.12.0.20250516"
+description = "Typing stubs for beautifulsoup4"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "types_beautifulsoup4-4.12.0.20250516-py3-none-any.whl", hash = "sha256:5923399d4a1ba9cc8f0096fe334cc732e130269541d66261bb42ab039c0376ee"},
+    {file = "types_beautifulsoup4-4.12.0.20250516.tar.gz", hash = "sha256:aa19dd73b33b70d6296adf92da8ab8a0c945c507e6fb7d5db553415cc77b417e"},
+]
+
+[package.dependencies]
+types-html5lib = "*"
+
+[[package]]
+name = "types-html5lib"
+version = "1.1.11.20250708"
+description = "Typing stubs for html5lib"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "types_html5lib-1.1.11.20250708-py3-none-any.whl", hash = "sha256:bb898066b155de7081cb182179e2ded31b9e0e234605e2cb46536894e68a6954"},
+    {file = "types_html5lib-1.1.11.20250708.tar.gz", hash = "sha256:24321720fdbac71cee50d5a4bec9b7448495b7217974cffe3fcf1ede4eef7afe"},
 ]
 
 [[package]]
@@ -1846,4 +1924,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13.0"
-content-hash = "0753e3d88cfb29a9f91ad184b914b1a27069fc31370300c59497164ddaf06d31"
+content-hash = "6d4002291c3ca3ed536364aab89a836af0f82c6e78e06049de8ffe3b9f840ca9"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,9 @@ boto3-stubs = {extras = ["bedrock", "bedrock-agent-runtime", "bedrock-runtime", 
 firecrawl-py = "^1.11.1"
 reretry = "^0.11.8"
 pypdf = "^5.0.0"
+ebooklib = "^0.19"
+beautifulsoup4 = "^4.12.0"
+types-beautifulsoup4 = "^4.12.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.15.0"

--- a/backend/tests/test_repositories/test_epub_support.py
+++ b/backend/tests/test_repositories/test_epub_support.py
@@ -1,0 +1,340 @@
+import base64
+import io
+import sys
+import unittest
+
+# Mock imports removed - not needed for current tests
+import zipfile
+
+sys.path.insert(0, ".")
+
+from app.repositories.models.conversation import AttachmentContentModel
+
+
+class TestEPUBSupport(unittest.TestCase):
+    def setUp(self):
+        """Set up test fixtures"""
+        # Create a minimal valid EPUB file for testing
+        self.minimal_epub_content = self._create_minimal_epub()
+        self.minimal_epub_b64 = base64.b64encode(self.minimal_epub_content).decode(
+            "utf-8"
+        )
+
+        # Create corrupted EPUB data
+        self.corrupted_epub_content = b"Not a valid EPUB file"
+        self.corrupted_epub_b64 = base64.b64encode(self.corrupted_epub_content).decode(
+            "utf-8"
+        )
+
+    def _create_minimal_epub(self) -> bytes:
+        """Create a minimal valid EPUB file for testing"""
+        epub_buffer = io.BytesIO()
+
+        with zipfile.ZipFile(epub_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+            # Add mimetype file (must be uncompressed and first)
+            zip_file.writestr(
+                "mimetype", "application/epub+zip", compress_type=zipfile.ZIP_STORED
+            )
+
+            # Add META-INF/container.xml
+            container_xml = """<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+    <rootfiles>
+        <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+    </rootfiles>
+</container>"""
+            zip_file.writestr("META-INF/container.xml", container_xml)
+
+            # Add content.opf
+            content_opf = """<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="bookid" version="2.0">
+    <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <dc:title>Test Book</dc:title>
+        <dc:creator>Test Author</dc:creator>
+        <dc:identifier id="bookid">test-book-1</dc:identifier>
+        <dc:language>en</dc:language>
+    </metadata>
+    <manifest>
+        <item id="chapter1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+    </manifest>
+    <spine>
+        <itemref idref="chapter1"/>
+    </spine>
+</package>"""
+            zip_file.writestr("OEBPS/content.opf", content_opf)
+
+            # Add chapter1.xhtml
+            chapter1_xhtml = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Chapter 1</title>
+</head>
+<body>
+    <h1>Chapter 1: The Beginning</h1>
+    <p>This is the first paragraph of the test book.</p>
+    <p>This is the second paragraph with some content.</p>
+    <div>This is a div with text content.</div>
+</body>
+</html>"""
+            zip_file.writestr("OEBPS/chapter1.xhtml", chapter1_xhtml)
+
+        epub_buffer.seek(0)
+        return epub_buffer.read()
+
+    def test_epub_file_type_recognized(self):
+        """Test that .epub files are recognized as supported document format"""
+        from app.repositories.models.conversation import (
+            _is_converse_supported_document_format,
+        )
+
+        self.assertTrue(_is_converse_supported_document_format("epub"))
+
+    def test_epub_mime_type_mapping(self):
+        """Test that .epub files get correct MIME type"""
+        attachment = AttachmentContentModel(
+            content_type="attachment",
+            body=self.minimal_epub_b64,
+            file_name="test_book.epub",
+        )
+
+        result = attachment.to_contents_for_invoke()
+
+        # Should extract text and convert to HTML
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["type"], "document")
+        self.assertEqual(result[0]["source"]["type"], "base64")
+        self.assertEqual(result[0]["source"]["media_type"], "text/html")
+
+    def test_epub_text_extraction_success(self):
+        """Test successful EPUB text extraction and conversion to HTML"""
+        attachment = AttachmentContentModel(
+            content_type="attachment",
+            body=self.minimal_epub_b64,
+            file_name="test_book.epub",
+        )
+
+        result = attachment.to_contents_for_invoke()
+
+        # Should return HTML document format
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["type"], "document")
+        self.assertEqual(result[0]["source"]["media_type"], "text/html")
+
+        # Decode and verify HTML content contains extracted text
+        html_data = base64.b64decode(result[0]["source"]["data"]).decode("utf-8")
+        self.assertIn("<html>", html_data)
+        self.assertIn("<body>", html_data)
+        self.assertIn("test_book", html_data)  # Title from filename
+        self.assertIn("Chapter 1: The Beginning", html_data)
+        self.assertIn("first paragraph", html_data)
+        self.assertIn("second paragraph", html_data)
+
+    def test_epub_corrupted_file_handling(self):
+        """Test graceful handling of corrupted EPUB files"""
+        attachment = AttachmentContentModel(
+            content_type="attachment",
+            body=self.corrupted_epub_b64,
+            file_name="corrupted.epub",
+        )
+
+        result = attachment.to_contents_for_invoke()
+
+        # Should return error message as text
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["type"], "text")
+        self.assertIn("Could not extract text", result[0]["text"])
+        self.assertIn("corrupted.epub", result[0]["text"])
+
+    def test_epub_empty_content_handling(self):
+        """Test handling of EPUB files that don't extract any text"""
+        # Create EPUB with no readable content
+        epub_buffer = io.BytesIO()
+        with zipfile.ZipFile(epub_buffer, "w") as zip_file:
+            zip_file.writestr("mimetype", "application/epub+zip")
+            # Add minimal structure but no readable content
+            container_xml = """<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+    <rootfiles>
+        <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
+    </rootfiles>
+</container>"""
+            zip_file.writestr("META-INF/container.xml", container_xml)
+
+        empty_epub_content = epub_buffer.getvalue()
+        empty_epub_b64 = base64.b64encode(empty_epub_content).decode("utf-8")
+
+        attachment = AttachmentContentModel(
+            content_type="attachment",
+            body=empty_epub_b64,
+            file_name="empty.epub",
+        )
+
+        result = attachment.to_contents_for_invoke()
+
+        # Should return error message about no extractable text
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["type"], "text")
+        self.assertIn("Could not extract text", result[0]["text"])
+        self.assertIn("empty.epub", result[0]["text"])
+
+    def test_epub_missing_dependency_handling(self):
+        """Test handling when ebooklib produces an error"""
+        # Use an invalid EPUB that will cause ebooklib to fail
+        invalid_epub = b"Invalid EPUB content that will fail"
+        invalid_epub_b64 = base64.b64encode(invalid_epub).decode("utf-8")
+
+        attachment = AttachmentContentModel(
+            content_type="attachment",
+            body=invalid_epub_b64,
+            file_name="invalid.epub",
+        )
+
+        result = attachment.to_contents_for_invoke()
+
+        # Should return error message when processing fails
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["type"], "text")
+        self.assertIn("Could not extract text", result[0]["text"])
+
+    def test_epub_converse_api_format(self):
+        """Test EPUB processing for Converse API format"""
+        attachment = AttachmentContentModel(
+            content_type="attachment",
+            body=self.minimal_epub_b64,
+            file_name="test_book.epub",
+        )
+
+        result = attachment.to_contents_for_converse()
+
+        # Should return document format for Converse API since epub is supported
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["document"]["format"], "epub")
+        self.assertEqual(result[0]["document"]["name"], "testbook")
+
+    def test_epub_various_text_elements_extraction(self):
+        """Test that various HTML elements are properly extracted from EPUB"""
+        # Create EPUB with various text elements
+        epub_buffer = io.BytesIO()
+
+        with zipfile.ZipFile(epub_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+            zip_file.writestr(
+                "mimetype", "application/epub+zip", compress_type=zipfile.ZIP_STORED
+            )
+
+            container_xml = """<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+    <rootfiles>
+        <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
+    </rootfiles>
+</container>"""
+            zip_file.writestr("META-INF/container.xml", container_xml)
+
+            content_opf = """<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="bookid" version="2.0">
+    <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <dc:title>Test Book</dc:title>
+    </metadata>
+    <manifest>
+        <item id="chapter1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+    </manifest>
+    <spine>
+        <itemref idref="chapter1"/>
+    </spine>
+</package>"""
+            zip_file.writestr("content.opf", content_opf)
+
+            # Chapter with various text elements
+            chapter1_xhtml = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Test Chapter</title>
+</head>
+<body>
+    <h1>Main Heading</h1>
+    <h2>Sub Heading</h2>
+    <p>Paragraph text</p>
+    <div>Div text content</div>
+    <span>Span text content</span>
+    <h3>Another heading</h3>
+    <p>More paragraph content</p>
+</body>
+</html>"""
+            zip_file.writestr("chapter1.xhtml", chapter1_xhtml)
+
+        complex_epub_content = epub_buffer.getvalue()
+        complex_epub_b64 = base64.b64encode(complex_epub_content).decode("utf-8")
+
+        attachment = AttachmentContentModel(
+            content_type="attachment",
+            body=complex_epub_b64,
+            file_name="complex_book.epub",
+        )
+
+        result = attachment.to_contents_for_invoke()
+
+        # Verify various text elements are extracted
+        html_data = base64.b64decode(result[0]["source"]["data"]).decode("utf-8")
+        self.assertIn("Main Heading", html_data)
+        self.assertIn("Sub Heading", html_data)
+        self.assertIn("Paragraph text", html_data)
+        self.assertIn("Div text content", html_data)
+        self.assertIn("Span text content", html_data)
+        self.assertIn("Another heading", html_data)
+
+    def test_epub_base64_vs_bytes_handling(self):
+        """Test that both base64 strings and bytes are handled correctly for EPUB"""
+        # Test with bytes
+        attachment_bytes = AttachmentContentModel(
+            content_type="attachment",
+            body=self.minimal_epub_content,  # Raw bytes
+            file_name="test_bytes.epub",
+        )
+
+        # Test with base64 string
+        attachment_string = AttachmentContentModel(
+            content_type="attachment",
+            body=self.minimal_epub_b64,  # Base64 string
+            file_name="test_string.epub",
+        )
+
+        result_bytes = attachment_bytes.to_contents_for_invoke()
+        result_string = attachment_string.to_contents_for_invoke()
+
+        # Both should work and return HTML document format
+        self.assertEqual(result_bytes[0]["type"], "document")
+        self.assertEqual(result_bytes[0]["source"]["media_type"], "text/html")
+        self.assertEqual(result_string[0]["type"], "document")
+        self.assertEqual(result_string[0]["source"]["media_type"], "text/html")
+
+    def test_epub_invoke_format_structure(self):
+        """Test that the EPUB invoke format structure is correct"""
+        attachment = AttachmentContentModel(
+            content_type="attachment",
+            body=self.minimal_epub_b64,
+            file_name="test.epub",
+        )
+
+        result = attachment.to_contents_for_invoke()
+
+        # Verify the structure matches Claude 4 invoke API format
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["type"], "document")
+        self.assertIn("source", result[0])
+        self.assertEqual(result[0]["source"]["type"], "base64")
+        self.assertEqual(result[0]["source"]["media_type"], "text/html")
+        self.assertIn("data", result[0]["source"])
+
+        # Verify the data is valid base64
+        try:
+            decoded_html = base64.b64decode(result[0]["source"]["data"]).decode("utf-8")
+            # Verify it's valid HTML
+            self.assertIn("<html>", decoded_html)
+            self.assertIn("</html>", decoded_html)
+        except Exception:
+            self.fail("EPUB converted HTML data is not valid base64 or HTML")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_repositories/test_epub_support.py
+++ b/backend/tests/test_repositories/test_epub_support.py
@@ -91,7 +91,7 @@ class TestEPUBSupport(unittest.TestCase):
         self.assertTrue(_is_converse_supported_document_format("epub"))
 
     def test_epub_mime_type_mapping(self):
-        """Test that .epub files get correct MIME type"""
+        """Test that .epub files get correct handling for invoke API"""
         attachment = AttachmentContentModel(
             content_type="attachment",
             body=self.minimal_epub_b64,
@@ -100,14 +100,13 @@ class TestEPUBSupport(unittest.TestCase):
 
         result = attachment.to_contents_for_invoke()
 
-        # Should extract text and convert to HTML
+        # Should extract text and return as text format for invoke API
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["type"], "document")
-        self.assertEqual(result[0]["source"]["type"], "base64")
-        self.assertEqual(result[0]["source"]["media_type"], "text/html")
+        self.assertEqual(result[0]["type"], "text")
+        self.assertIn("[EPUB Document: test_book.epub]", result[0]["text"])
 
     def test_epub_text_extraction_success(self):
-        """Test successful EPUB text extraction and conversion to HTML"""
+        """Test successful EPUB text extraction for invoke API"""
         attachment = AttachmentContentModel(
             content_type="attachment",
             body=self.minimal_epub_b64,
@@ -116,19 +115,16 @@ class TestEPUBSupport(unittest.TestCase):
 
         result = attachment.to_contents_for_invoke()
 
-        # Should return HTML document format
+        # Should return text format for invoke API
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["type"], "document")
-        self.assertEqual(result[0]["source"]["media_type"], "text/html")
+        self.assertEqual(result[0]["type"], "text")
 
-        # Decode and verify HTML content contains extracted text
-        html_data = base64.b64decode(result[0]["source"]["data"]).decode("utf-8")
-        self.assertIn("<html>", html_data)
-        self.assertIn("<body>", html_data)
-        self.assertIn("test_book", html_data)  # Title from filename
-        self.assertIn("Chapter 1: The Beginning", html_data)
-        self.assertIn("first paragraph", html_data)
-        self.assertIn("second paragraph", html_data)
+        # Verify text content contains extracted text
+        text_content = result[0]["text"]
+        self.assertIn("[EPUB Document: test_book.epub]", text_content)
+        self.assertIn("Chapter 1: The Beginning", text_content)
+        self.assertIn("first paragraph", text_content)
+        self.assertIn("second paragraph", text_content)
 
     def test_epub_corrupted_file_handling(self):
         """Test graceful handling of corrupted EPUB files"""
@@ -275,13 +271,13 @@ class TestEPUBSupport(unittest.TestCase):
         result = attachment.to_contents_for_invoke()
 
         # Verify various text elements are extracted
-        html_data = base64.b64decode(result[0]["source"]["data"]).decode("utf-8")
-        self.assertIn("Main Heading", html_data)
-        self.assertIn("Sub Heading", html_data)
-        self.assertIn("Paragraph text", html_data)
-        self.assertIn("Div text content", html_data)
-        self.assertIn("Span text content", html_data)
-        self.assertIn("Another heading", html_data)
+        text_content = result[0]["text"]
+        self.assertIn("Main Heading", text_content)
+        self.assertIn("Sub Heading", text_content)
+        self.assertIn("Paragraph text", text_content)
+        self.assertIn("Div text content", text_content)
+        self.assertIn("Span text content", text_content)
+        self.assertIn("Another heading", text_content)
 
     def test_epub_base64_vs_bytes_handling(self):
         """Test that both base64 strings and bytes are handled correctly for EPUB"""
@@ -302,11 +298,11 @@ class TestEPUBSupport(unittest.TestCase):
         result_bytes = attachment_bytes.to_contents_for_invoke()
         result_string = attachment_string.to_contents_for_invoke()
 
-        # Both should work and return HTML document format
-        self.assertEqual(result_bytes[0]["type"], "document")
-        self.assertEqual(result_bytes[0]["source"]["media_type"], "text/html")
-        self.assertEqual(result_string[0]["type"], "document")
-        self.assertEqual(result_string[0]["source"]["media_type"], "text/html")
+        # Both should work and return text format for invoke API
+        self.assertEqual(result_bytes[0]["type"], "text")
+        self.assertIn("[EPUB Document:", result_bytes[0]["text"])
+        self.assertEqual(result_string[0]["type"], "text")
+        self.assertIn("[EPUB Document:", result_string[0]["text"])
 
     def test_epub_invoke_format_structure(self):
         """Test that the EPUB invoke format structure is correct"""
@@ -318,22 +314,15 @@ class TestEPUBSupport(unittest.TestCase):
 
         result = attachment.to_contents_for_invoke()
 
-        # Verify the structure matches Claude 4 invoke API format
+        # Verify the structure matches Claude 4 invoke API format (text format for EPUB)
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["type"], "document")
-        self.assertIn("source", result[0])
-        self.assertEqual(result[0]["source"]["type"], "base64")
-        self.assertEqual(result[0]["source"]["media_type"], "text/html")
-        self.assertIn("data", result[0]["source"])
-
-        # Verify the data is valid base64
-        try:
-            decoded_html = base64.b64decode(result[0]["source"]["data"]).decode("utf-8")
-            # Verify it's valid HTML
-            self.assertIn("<html>", decoded_html)
-            self.assertIn("</html>", decoded_html)
-        except Exception:
-            self.fail("EPUB converted HTML data is not valid base64 or HTML")
+        self.assertEqual(result[0]["type"], "text")
+        self.assertIn("text", result[0])
+        
+        # Verify the text contains the document header and extracted content
+        text_content = result[0]["text"]
+        self.assertIn("[EPUB Document: test.epub]", text_content)
+        self.assertIsInstance(text_content, str)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_repositories/test_epub_support.py
+++ b/backend/tests/test_repositories/test_epub_support.py
@@ -318,7 +318,7 @@ class TestEPUBSupport(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["type"], "text")
         self.assertIn("text", result[0])
-        
+
         # Verify the text contains the document header and extracted content
         text_content = result[0]["text"]
         self.assertIn("[EPUB Document: test.epub]", text_content)

--- a/backend/tests/test_repositories/test_pdf_validation.py
+++ b/backend/tests/test_repositories/test_pdf_validation.py
@@ -81,6 +81,7 @@ class TestPDFPageValidation(unittest.TestCase):
                 "data.xlsx",
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             ),
+            ("book.epub", "application/epub+zip"),
             ("unknown.xyz", "application/octet-stream"),
         ]
 
@@ -93,7 +94,17 @@ class TestPDFPageValidation(unittest.TestCase):
                 )
 
                 result = attachment.to_contents_for_invoke()
-                self.assertEqual(result[0]["source"]["media_type"], expected_mime)
+
+                # EPUB files get special processing, so check accordingly
+                if filename.endswith(".epub"):
+                    # EPUB should be converted to HTML due to text extraction
+                    if result[0]["type"] == "document":
+                        self.assertEqual(result[0]["source"]["media_type"], "text/html")
+                    else:
+                        # If extraction failed, it returns text format
+                        self.assertEqual(result[0]["type"], "text")
+                else:
+                    self.assertEqual(result[0]["source"]["media_type"], expected_mime)
 
     def test_base64_string_vs_bytes_handling(self):
         """Test that both base64 strings and bytes are handled correctly"""

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -11,7 +11,12 @@ In this sample, you can locally modify and launch the frontend using AWS resourc
 1. Refer to [Deploy using CDK](../README.md#deploy-using-cdk) for deploying on the AWS environment.
 2. Copy the `frontend/.env.template` and save it as `frontend/.env.local`.
 3. Fill in the contents of `.env.local` based on the output results of `npx cdk deploy` (such as `BedrockChatStack.AuthUserPoolClientIdXXXXX`).
-4. Execute the following command:
+4. **Important**: Use `localhost` (not `0.0.0.0`) for API endpoints in frontend `.env.local`:
+   ```
+   VITE_APP_API_ENDPOINT="http://localhost:8000"
+   VITE_APP_WS_ENDPOINT="ws://localhost:8000"
+   ```
+5. Execute the following command:
 
 ```zsh
 cd frontend && npm ci && npm run dev

--- a/frontend/src/constants/supportedAttachedFiles.ts
+++ b/frontend/src/constants/supportedAttachedFiles.ts
@@ -62,6 +62,7 @@ export const NON_TEXT_FILE_EXTENSIONS = [
   '.docx',
   '.xls',
   '.xlsx',
+  '.epub',
 ];
 
 export const SUPPORTED_FILE_EXTENSIONS = [


### PR DESCRIPTION
 [[Feature] Add EPUB file upload support for simple chat interface](https://app.asana.com/1/699783015176634/project/1209809496473362/task/1210760923454987?focus=true)

**Note: The EPUB support is experimental and only available for Claude 4.**

### EPUB File Support

* Added EPUB as a supported document format in `backend/app/repositories/models/conversation.py`, including MIME type mapping and special handling to extract text content using `ebooklib` and `BeautifulSoup`.
* Introduced new dependencies (`ebooklib`, `beautifulsoup4`, and `types-beautifulsoup4`) in `backend/pyproject.toml` to enable EPUB processing.
* Added comprehensive unit tests in `backend/tests/test_repositories/test_epub_support.py` to validate EPUB handling, including scenarios for valid, corrupted, and empty EPUB files.
* Updated existing tests in `backend/tests/test_repositories/test_pdf_validation.py` to include assertions for EPUB-specific behavior. 

### Local Development Improvements

* Updated `backend/README.md` to standardize `.env` file usage and ensure environment variables are loaded when starting the local server. 
* Revised `docs/LOCAL_DEVELOPMENT.md` to emphasize using `localhost` instead of `0.0.0.0` for frontend API endpoints in local `.env.local` configuration.

### Frontend Updates

* Added `.epub` to the list of non-text file extensions in `frontend/src/constants/supportedAttachedFiles.ts`.