### PR TITLE
Fix for random character artifacts and code fragments appearing in bot responses

### DIFF
--- a/backend/app/stream.py
+++ b/backend/app/stream.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from typing import Callable, TypedDict, TypeGuard
 
 from app.agents.tools.agent_tool import AgentTool
@@ -96,13 +97,28 @@ def _is_reasoning_content(
     return "signature" in content or "redacted_content" in content
 
 
+def _sanitize_text(text: str) -> str:
+    """Remove internal processing artifacts from text content."""
+    # Remove internal tool use patterns (not legitimate citations)
+    text = re.sub(r"\[\^tooluse_[^]]+\]", "", text)
+    text = re.sub(r"\[\^new-message-assistant[^]]*\]", "", text)
+
+    # Remove any stray tool_use_id patterns
+    text = re.sub(r"tool_use_id:\s*[A-Za-z0-9_-]+", "", text)
+
+    # Remove JSON fragments that might leak
+    text = re.sub(r'{"tool_use":[^}]*}', "", text)
+
+    return text.strip()
+
+
 def _content_model_from_partial_content(
     content: _PartialTextContent | _PartialToolUseContent,
 ) -> ContentModel:
     if _is_text_content(content=content):
         return TextContentModel(
             content_type="text",
-            body=content["text"].rstrip(),
+            body=_sanitize_text(content["text"].rstrip()),
         )
 
     elif _is_tool_use_content(content=content):


### PR DESCRIPTION
- sanitize text content in `_content_model_from_partial_content`
- Introduce `_sanitize_text` helper to clean up internal processing artifacts from text. This includes removing tool use patterns, stray IDs, and JSON fragments. 
- Update `_content_model_from_partial_content` to apply text sanitization.

https://app.asana.com/1/699783015176634/project/1209809496473362/task/1210625723518846?focus=true